### PR TITLE
Settings upload

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -95,6 +95,20 @@
             "settings.users.write.*",
             "settings.owner.write.*"
           ]
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "pathPattern": "/settings/upload",
+          "permissionsRequired": [
+            "settings.entries.upload"
+          ],
+          "permissionsDesired": [
+            "settings.global.write.*",
+            "settings.users.write.*",
+            "settings.owner.write.*"
+          ]
         }
       ]
     }
@@ -127,6 +141,11 @@
       "description": "Delete setting"
     },
     {
+      "permissionName": "settings.entries.upload",
+      "displayName": "settings - upload",
+      "description": "Upload settings"
+    },
+    {
       "permissionName": "settings.entries.all",
       "displayName": "settings - all setting permissions",
       "description": "All setting permissions",
@@ -135,7 +154,8 @@
         "settings.entries.collection.get",
         "settings.entries.item.get",
         "settings.entries.item.put",
-        "settings.entries.item.delete"
+        "settings.entries.item.delete",
+        "settings.entries.upload"
       ]
     }
   ],

--- a/src/main/java/org/folio/settings/server/service/SettingsService.java
+++ b/src/main/java/org/folio/settings/server/service/SettingsService.java
@@ -3,6 +3,7 @@ package org.folio.settings.server.service;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
@@ -38,7 +39,12 @@ public class SettingsService implements RouterCreator, TenantInitHooks {
           // https://vertx.io/docs/vertx-web/java/#_limiting_body_size
           routerBuilder.rootHandler(BodyHandler.create().setBodyLimit(BODY_LIMIT));
           handlers(routerBuilder);
-          return routerBuilder.createRouter();
+          Router router = Router.router(vertx);
+          router.put("/settings/upload")
+              .handler(ctx -> UploadService.uploadEntries(ctx)
+                  .onFailure(cause -> commonError(ctx, cause)));
+          router.route("/*").subRouter(routerBuilder.createRouter());
+          return router;
         });
   }
 
@@ -100,13 +106,7 @@ public class SettingsService implements RouterCreator, TenantInitHooks {
         .failureHandler(this::failureHandler);
   }
 
-  /**
-   * Helper to create SettingsStorage from routing context.
-   * @param ctx rouging context.
-   * @return SettingsStorage instance
-   */
-  public static SettingsStorage create(RoutingContext ctx) {
-    RequestParameters params = ctx.get(ValidationHandler.REQUEST_CONTEXT_KEY);
+  static SettingsStorage createFromParams(Vertx vertx, RequestParameters params) {
     // get tenant
     RequestParameter tenantParameter = params.headerParameter(XOkapiHeaders.TENANT);
     String tenant = tenantParameter.getString();
@@ -126,7 +126,32 @@ public class SettingsService implements RouterCreator, TenantInitHooks {
     } else {
       permissions = new JsonArray();
     }
-    return new SettingsStorage(ctx.vertx(), tenant, currentUserId, permissions);
+    return new SettingsStorage(vertx, tenant, currentUserId, permissions);
+  }
+
+  static SettingsStorage create(RoutingContext ctx) {
+    return createFromParams(ctx.vertx(), ctx.get(ValidationHandler.REQUEST_CONTEXT_KEY));
+  }
+
+  static SettingsStorage create(Vertx vertx, HttpServerRequest params) {
+    // get tenant
+    String tenant = params.getHeader(XOkapiHeaders.TENANT);
+
+    // get user Id
+    String userIdParameter = params.getHeader(XOkapiHeaders.USER_ID);
+    UUID currentUserId = null;
+    if (userIdParameter != null) {
+      currentUserId = UUID.fromString(userIdParameter);
+    }
+    // get permissions
+    String okapiPermissions = params.getHeader(XOkapiHeaders.PERMISSIONS);
+    JsonArray permissions;
+    if (okapiPermissions != null) {
+      permissions = new JsonArray(okapiPermissions);
+    } else {
+      permissions = new JsonArray();
+    }
+    return new SettingsStorage(vertx, tenant, currentUserId, permissions);
   }
 
   Future<Void> postSetting(RoutingContext ctx) {
@@ -188,9 +213,9 @@ public class SettingsService implements RouterCreator, TenantInitHooks {
     RequestParameters params = ctx.get(ValidationHandler.REQUEST_CONTEXT_KEY);
     RequestParameter queryParameter = params.queryParameter("query");
     String query = queryParameter != null ? queryParameter.getString() : null;
-    RequestParameter limitParameter = params.pathParameter("limit");
+    RequestParameter limitParameter = params.queryParameter("limit");
     int limit = limitParameter != null ? limitParameter.getInteger() : 10;
-    RequestParameter offsetParameter = params.pathParameter("offset");
+    RequestParameter offsetParameter = params.queryParameter("offset");
     int offset = offsetParameter != null ? offsetParameter.getInteger() : 0;
     return storage.getEntries(ctx.response(), query, offset, limit);
   }

--- a/src/main/java/org/folio/settings/server/service/UploadService.java
+++ b/src/main/java/org/folio/settings/server/service/UploadService.java
@@ -45,11 +45,12 @@ public class UploadService {
             jsonParser.pause();
           }
           storage.upsertEntry(entry)
-              .onFailure(promise::tryFail)
-              .onSuccess(b -> {
+              .map(b -> {
                 String key = Boolean.TRUE.equals(b) ? "inserted" : "updated";
                 uploadResponse.put(key, uploadResponse.getInteger(key) + 1);
+                return null;
               })
+              .onFailure(promise::tryFail)
               .onComplete(x -> {
                 if (pending.decrementAndGet() <= 2) {
                   jsonParser.resume();

--- a/src/main/java/org/folio/settings/server/service/UploadService.java
+++ b/src/main/java/org/folio/settings/server/service/UploadService.java
@@ -1,0 +1,77 @@
+package org.folio.settings.server.service;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.parsetools.JsonEventType;
+import io.vertx.core.parsetools.JsonParser;
+import io.vertx.ext.web.RoutingContext;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.folio.okapi.common.HttpResponse;
+import org.folio.settings.server.data.Entry;
+import org.folio.settings.server.storage.SettingsStorage;
+import org.folio.settings.server.storage.UserException;
+
+public class UploadService {
+
+  static Future<Void> uploadEntries(RoutingContext ctx) {
+    try {
+      String contentType = ctx.request().getHeader(HttpHeaders.CONTENT_TYPE);
+      if (contentType == null || !contentType.startsWith("application/json")) {
+        throw new UserException("Content-Type must be application/json");
+      }
+      SettingsStorage storage = SettingsService.create(ctx.vertx(), ctx.request());
+      JsonParser jsonParser = JsonParser.newParser(ctx.request());
+      JsonObject uploadResponse = new JsonObject()
+          .put("inserted", 0)
+          .put("updated", 0);
+
+      Promise<Void> promise = Promise.promise();
+      AtomicInteger pending = new AtomicInteger();
+      AtomicBoolean ended = new AtomicBoolean();
+      jsonParser.handler(event -> {
+        if (event.type().equals(JsonEventType.START_ARRAY)) {
+          jsonParser.objectValueMode();
+        } else if (event.type().equals(JsonEventType.END_ARRAY)) {
+          jsonParser.objectEventMode();
+        } else if (event.type().equals(JsonEventType.VALUE)) {
+          JsonObject obj = event.objectValue();
+          Entry entry = obj.mapTo(Entry.class);
+          if (pending.incrementAndGet() >= 5) {
+            jsonParser.pause();
+          }
+          storage.upsertEntry(entry)
+              .onFailure(promise::tryFail)
+              .onSuccess(b -> {
+                String key = b ? "inserted" : "updated";
+                uploadResponse.put(key, uploadResponse.getInteger(key) + 1);
+              })
+              .onComplete(x -> {
+                if (pending.decrementAndGet() <= 2) {
+                  jsonParser.resume();
+                }
+                if (ended.get() && pending.get() == 0) {
+                  promise.tryComplete();
+                }
+              });
+        }
+      });
+      jsonParser.endHandler(x -> {
+        ended.set(true);
+        if (pending.get() == 0) {
+          promise.tryComplete();
+        }
+      });
+      // turn JSON parse errors to user errors : bad request body
+      jsonParser.exceptionHandler(x -> promise.tryFail(new UserException(x.getMessage())));
+      return promise.future().map(x -> {
+        HttpResponse.responseJson(ctx, 200).end(uploadResponse.encode());
+        return null;
+      });
+    } catch (Exception e) {
+      return Future.failedFuture(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/settings/server/service/UploadService.java
+++ b/src/main/java/org/folio/settings/server/service/UploadService.java
@@ -16,6 +16,8 @@ import org.folio.settings.server.storage.UserException;
 
 public class UploadService {
 
+  private UploadService() { }
+
   static Future<Void> uploadEntries(RoutingContext ctx) {
     try {
       String contentType = ctx.request().getHeader(HttpHeaders.CONTENT_TYPE);
@@ -45,7 +47,7 @@ public class UploadService {
           storage.upsertEntry(entry)
               .onFailure(promise::tryFail)
               .onSuccess(b -> {
-                String key = b ? "inserted" : "updated";
+                String key = Boolean.TRUE.equals(b) ? "inserted" : "updated";
                 uploadResponse.put(key, uploadResponse.getInteger(key) + 1);
               })
               .onComplete(x -> {

--- a/src/main/java/org/folio/settings/server/storage/SettingsStorage.java
+++ b/src/main/java/org/folio/settings/server/storage/SettingsStorage.java
@@ -2,6 +2,7 @@ package org.folio.settings.server.storage;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -151,6 +152,12 @@ public class SettingsStorage {
     return entry;
   }
 
+  static String getOnConflictClause(Entry entry) {
+    return entry.getUserId() != null
+        ? "ON CONFLICT (scope, key, userId) WHERE userId is NOT NULL"
+        : "ON CONFLICT (scope, key) WHERE userId is NULL";
+  }
+
   /**
    * Create configurations entry.
    *
@@ -161,14 +168,11 @@ public class SettingsStorage {
     if (!checkDesiredPermissions("write", permissions, entry, currentUser)) {
       return Future.failedFuture(new ForbiddenException());
     }
-    String constraintWhere = entry.getUserId() != null
-        ? "ON CONFLICT (scope, key, userId) WHERE userId is NOT NULL DO NOTHING"
-        : "ON CONFLICT (scope, key) WHERE userId is NULL DO NOTHING";
     return pool.preparedQuery(
             "INSERT INTO " + settingsTable
                 + " (id, scope, key, value, userId)"
                 + " VALUES ($1, $2, $3, $4, $5)"
-                + constraintWhere
+                + getOnConflictClause(entry) + " DO NOTHING"
         )
         .execute(Tuple.of(entry.getId(), entry.getScope(),
             entry.getKey(), entry.getValue(),
@@ -275,6 +279,32 @@ public class SettingsStorage {
   }
 
   /**
+   * Upsert settings entry.
+   * @param entry new entry or entry with new value
+   * @return async result with true if inserted; false if updated
+   */
+  public Future<Boolean> upsertEntry(Entry entry) {
+    if (entry.getId() != null) {
+      return Future.failedFuture(new UserException("No id must supplied for upload"));
+    }
+    entry.setId(UUID.randomUUID());
+    if (!checkDesiredPermissions("write", permissions, entry, currentUser)) {
+      return Future.failedFuture(new ForbiddenException());
+    }
+    return pool.preparedQuery(
+            "INSERT INTO " + settingsTable
+                + "(id, scope, key, value, userId)"
+                + " VALUES ($1, $2, $3, $4, $5)"
+              + getOnConflictClause(entry) + " DO UPDATE SET value = $4"
+              + " RETURNING id"
+        )
+        .execute(Tuple.of(entry.getId(), entry.getScope(),
+            entry.getKey(), entry.getValue(),
+            entry.getUserId()))
+        .map(rowSet -> rowSet.iterator().next().getUUID("id").equals(entry.getId()));
+  }
+
+  /**
    * Get entries with optional cqlQuery.
    *
    * @param response HTTP response for result
@@ -324,7 +354,7 @@ public class SettingsStorage {
         .compose(pq ->
             connection.begin().map(tx -> {
               response.setChunked(true);
-              response.putHeader("Content-Type", "application/json");
+              response.putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
               response.write("{ \"" + property + "\" : [");
               AtomicBoolean first = new AtomicBoolean(true);
               RowStream<Row> stream = pq.createStream(sqlStreamFetchSize, tuple);

--- a/src/main/resources/openapi/schemas/uploadRequest.json
+++ b/src/main/resources/openapi/schemas/uploadRequest.json
@@ -1,0 +1,30 @@
+{
+  "description": "Settings upload request body",
+  "type": "array",
+   "items": {
+     "type": "object",
+     "properties": {
+       "scope": {
+         "type": "string",
+         "description": "Scope for this entry (normally a module)"
+       },
+       "key": {
+         "type": "string",
+         "description": "Key within scope for this setting"
+       },
+       "value": {
+         "type": "object",
+         "description": "Settings value"
+       },
+       "userId": {
+         "type": "string",
+         "format": "uuid",
+         "description": "Owner of this setting (optional)"
+       }
+     },
+     "additionalProperties": false,
+     "required": [
+       "scope", "key", "value"
+     ]
+   }
+}

--- a/src/main/resources/openapi/schemas/uploadResponse.json
+++ b/src/main/resources/openapi/schemas/uploadResponse.json
@@ -1,0 +1,18 @@
+{
+  "description": "Upload response",
+  "type": "object",
+  "properties": {
+    "inserted": {
+      "type": "integer",
+      "description": "Number of settings inserted"
+    },
+    "updated": {
+      "type": "integer",
+      "description": "Number of settings updated"
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "inserted", "updated"
+  ]
+}

--- a/src/main/resources/openapi/settings.yaml
+++ b/src/main/resources/openapi/settings.yaml
@@ -39,11 +39,11 @@ paths:
     post:
       description: >
         Create setting entry.
-        If X-Okapi-Permissions includes settings.global.read, then a setting without
+        If X-Okapi-Permissions includes settings.global.write, then a setting without
         a userId may be created.
-        If X-Okapi-Permissions includes settings.users.read, then a setting with a
+        If X-Okapi-Permissions includes settings.users.write, then a setting with a
         userId may be created.
-        If X-Okapi-Permissions includes settings.owner.read, then a setting with
+        If X-Okapi-Permissions includes settings.owner.write, then a setting with
         userId = current-user may be created.
       operationId: postSetting
       requestBody:
@@ -104,11 +104,11 @@ paths:
     put:
       description: >
         Update setting.
-        If X-Okapi-Permissions includes settings.global.read, then a setting without
+        If X-Okapi-Permissions includes settings.global.write, then a setting without
         a userId may be updated.
-        If X-Okapi-Permissions includes settings.users.read, then a setting with a
+        If X-Okapi-Permissions includes settings.users.write, then a setting with a
         userId may be updated.
-        If X-Okapi-Permissions includes settings.owner.read, then a setting with
+        If X-Okapi-Permissions includes settings.owner.write, then a setting with
         userId = current-user may be updated.
       operationId: putSetting
       requestBody:
@@ -132,11 +132,11 @@ paths:
     delete:
       description: >
         Delete setting.
-        If X-Okapi-Permissions includes settings.global.read, then a setting without
+        If X-Okapi-Permissions includes settings.global.write, then a setting without
         a userId may be deleted.
-        If X-Okapi-Permissions includes settings.users.read, then a setting with a
+        If X-Okapi-Permissions includes settings.users.write, then a setting with a
         userId may be deleted.
-        If X-Okapi-Permissions includes settings.owner.read, then a setting with
+        If X-Okapi-Permissions includes settings.owner.write, then a setting with
         userId = current-user may be deleted.
       operationId: deleteSetting
       responses:
@@ -148,6 +148,44 @@ paths:
           $ref: "#/components/responses/trait_404"
         "500":
           $ref: "#/components/responses/trait_500"
+  /settings/upload:
+    parameters:
+      - $ref: headers/okapi-permissions.yaml
+      - $ref: headers/okapi-tenant.yaml
+      - $ref: headers/okapi-token.yaml
+      - $ref: headers/okapi-url.yaml
+      - $ref: headers/okapi-user.yaml
+    put:
+      description: >
+        Upload settings. The entries are inserted or updated depending on whether
+        key, scope, userId already. Each entry gets a unique identifier assigned
+        if it's a new setting. The id must not be supplied.
+        If X-Okapi-Permissions includes settings.global.write, then a setting without
+        a userId may be created/updated.
+        If X-Okapi-Permissions includes settings.users.write, then a setting with a
+        userId may be created/updated.
+        If X-Okapi-Permissions includes settings.owner.write, then a setting with
+        userId = current-user may be created/updated.
+      operationId: uploadSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: schemas/uploadRequest.json
+      responses:
+        "200":
+          description: Settings uploaded
+          content:
+            application/json:
+              schema:
+                $ref: schemas/uploadResponse.json
+        "400":
+          $ref: "#/components/responses/trait_400"
+        "403":
+          $ref: "#/components/responses/trait_403"
+        "500":
+          $ref: "#/components/responses/trait_500"
+
 components:
   responses:
     trait_400:

--- a/src/test/java/org/folio/settings/server/main/MainVerticleTest.java
+++ b/src/test/java/org/folio/settings/server/main/MainVerticleTest.java
@@ -803,6 +803,35 @@ public class MainVerticleTest extends TestBase {
   }
 
   @Test
+  public void uploadIdMustNotBeSupplied() {
+    String scope = UUID.randomUUID().toString();
+    UUID userId = UUID.randomUUID();
+    JsonArray permOwnerWrite = new JsonArray().add("settings.owner.write." + scope);
+    int no = 2;
+    JsonArray ar = new JsonArray();
+    for (int i = 0; i < no; i++) {
+      JsonObject en = new JsonObject()
+          .put("id", UUID.randomUUID().toString())
+          .put("scope", scope)
+          .put("key", "k" + i)
+          .put("userId", userId.toString())
+          .put("value", new JsonObject().put("v", "thevalue"));
+      ar.add(en);
+    }
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, TENANT_1)
+        .header(XOkapiHeaders.USER_ID, userId.toString())
+        .header(XOkapiHeaders.PERMISSIONS, permOwnerWrite.encode())
+        .contentType(ContentType.JSON)
+        .body(ar.encode())
+        .put("/settings/upload")
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.TEXT)
+        .body(is("No id must supplied for upload"));
+  }
+
+  @Test
   public void testUploadOK() {
     String scope = UUID.randomUUID().toString();
     UUID userId = UUID.randomUUID();

--- a/src/test/java/org/folio/settings/server/main/MainVerticleTest.java
+++ b/src/test/java/org/folio/settings/server/main/MainVerticleTest.java
@@ -736,6 +736,28 @@ public class MainVerticleTest extends TestBase {
     RestAssured.given()
         .header(XOkapiHeaders.TENANT, TENANT_1)
         .header(XOkapiHeaders.USER_ID, userId.toString())
+        .contentType(ContentType.JSON)
+        .body(ar.encode())
+        .put("/settings/upload")
+        .then()
+        .statusCode(403)
+        .contentType(ContentType.TEXT)
+        .body(is("Forbidden"));
+
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, TENANT_1)
+        .header(XOkapiHeaders.PERMISSIONS, permissionsLacking.encode())
+        .contentType(ContentType.JSON)
+        .body(ar.encode())
+        .put("/settings/upload")
+        .then()
+        .statusCode(403)
+        .contentType(ContentType.TEXT)
+        .body(is("Forbidden"));
+
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, TENANT_1)
+        .header(XOkapiHeaders.USER_ID, userId.toString())
         .header(XOkapiHeaders.PERMISSIONS, permOwnerWrite.encode())
         .contentType(ContentType.TEXT)
         .body("Hello")


### PR DESCRIPTION
New endpoint /settings/upload allows insert/update of a list of settings. This is a streaming service, which allows request bodies of any size.

Fix also limit/offset parsing.

Fix descriptions of OpenAPI spec in a couple of places.