### PR TITLE
Require X-Okapi-Permissions

### DIFF
--- a/src/main/java/org/folio/settings/server/service/SettingsService.java
+++ b/src/main/java/org/folio/settings/server/service/SettingsService.java
@@ -145,12 +145,10 @@ public class SettingsService implements RouterCreator, TenantInitHooks {
     }
     // get permissions
     String okapiPermissions = params.getHeader(XOkapiHeaders.PERMISSIONS);
-    JsonArray permissions;
-    if (okapiPermissions != null) {
-      permissions = new JsonArray(okapiPermissions);
-    } else {
-      permissions = new JsonArray();
+    if (okapiPermissions == null) {
+      throw new UserException("Missing header " + XOkapiHeaders.PERMISSIONS);
     }
+    JsonArray permissions = new JsonArray(okapiPermissions);
     return new SettingsStorage(vertx, tenant, currentUserId, permissions);
   }
 

--- a/src/main/java/org/folio/settings/server/service/SettingsService.java
+++ b/src/main/java/org/folio/settings/server/service/SettingsService.java
@@ -118,14 +118,9 @@ public class SettingsService implements RouterCreator, TenantInitHooks {
       currentUserId = UUID.fromString(userIdParameter.getString());
     }
 
-    // get permissions
+    // get permissions which is required in OpenAPI spec
     RequestParameter okapiPermissions = params.headerParameter(XOkapiHeaders.PERMISSIONS);
-    JsonArray permissions;
-    if (okapiPermissions != null) {
-      permissions = new JsonArray(okapiPermissions.getString());
-    } else {
-      permissions = new JsonArray();
-    }
+    JsonArray permissions = new JsonArray(okapiPermissions.getString());
     return new SettingsStorage(vertx, tenant, currentUserId, permissions);
   }
 

--- a/src/main/resources/openapi/headers/okapi-permissions.yaml
+++ b/src/main/resources/openapi/headers/okapi-permissions.yaml
@@ -1,6 +1,6 @@
 in: header
 name: X-Okapi-Permissions
 description: A JSON array with client permissions
-required: false
+required: true
 schema:
   type: string

--- a/src/test/java/org/folio/settings/server/main/MainVerticleTest.java
+++ b/src/test/java/org/folio/settings/server/main/MainVerticleTest.java
@@ -124,6 +124,34 @@ public class MainVerticleTest extends TestBase {
   }
 
   @Test
+  public void testMissingPermissionsHeader() {
+    JsonObject en = new JsonObject()
+        .put("id", UUID.randomUUID().toString())
+        .put("scope", UUID.randomUUID().toString())
+        .put("key", "k1")
+        .put("value", new JsonObject().put("v", "thevalue"));
+
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, TENANT_1)
+        .contentType(ContentType.JSON)
+        .body(en.encode())
+        .post("/settings/entries")
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.TEXT)
+        .body(containsString("Missing parameter X-Okapi-Permissions in HEADER"));
+
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, TENANT_1)
+        .contentType(ContentType.JSON)
+        .get("/settings/entries")
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.TEXT)
+        .body(containsString("Missing parameter X-Okapi-Permissions in HEADER"));
+  }
+
+  @Test
   public void testPostInvalidSetting() {
     JsonObject en = new JsonObject()
         // id missing
@@ -223,13 +251,14 @@ public class MainVerticleTest extends TestBase {
   public void testNotFound() {
     RestAssured.given()
         .header(XOkapiHeaders.TENANT, TENANT_1)
+        .header(XOkapiHeaders.PERMISSIONS, "[]")
         .get("/settings/entries/" + UUID.randomUUID())
         .then()
         .statusCode(404);
 
-
     RestAssured.given()
         .header(XOkapiHeaders.TENANT, TENANT_1)
+        .header(XOkapiHeaders.PERMISSIONS, "[]")
         .delete("/settings/entries/" + UUID.randomUUID())
         .then()
         .statusCode(404);
@@ -749,9 +778,9 @@ public class MainVerticleTest extends TestBase {
         .body(ar.encode())
         .put("/settings/upload")
         .then()
-        .statusCode(403)
+        .statusCode(400)
         .contentType(ContentType.TEXT)
-        .body(is("Forbidden"));
+        .body(is("Missing header X-Okapi-Permissions"));
 
     RestAssured.given()
         .header(XOkapiHeaders.TENANT, TENANT_1)


### PR DESCRIPTION
Before, if omitted, [] would be assumed which would lead to forbidden. It's hardly a security risk to say what's fundamentally required:-)