### PR TITLE
MODSET-10: Vert.x 4.4.6, vertx-lib 3.1.3, Netty 4.1.100, Snakeyaml 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.19.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>4.4.6</version>
@@ -147,13 +154,6 @@
         <groupId>org.folio</groupId>
         <artifactId>vertx-lib-pg-testing</artifactId>
         <version>${vertxlib.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.19.0</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <okapi.version>4.14.10</okapi.version>
-    <vertxlib.version>3.0.0</vertxlib.version>
+    <vertxlib.version>3.1.3</vertxlib.version>
     <vertx.launcher>io.vertx.core.Launcher</vertx.launcher>
     <vertx.verticle>org.folio.settings.server.main.MainVerticle</vertx.verticle>
     <java.version>17</java.version>
@@ -99,7 +99,7 @@
     <!-- logging see http://www.slf4j.org/legacy.html -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -134,7 +134,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.6</version>
+        <version>4.4.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/MODSET-10

Upgrade Vert.x from 4.3.6 to 4.4.6.
Upgrade FOLIO vertx-lib from 3.0.0 to 3.1.3.
These upgrades are upgrades from Orchid versions to Poppy versions.

The Vert.x and vertx-lib upgrades indirectly upgrade
netty-codec-http2 from 4.1.85.Final to Netty 4.1.100.Final fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2023-44487

The Vert.x and vertx-lib upgrades indirectly upgrade
netty-codec from 4.1.85.Final to Netty 4.1.100.Final fixing HTTP Response Splitting:
https://nvd.nist.gov/vuln/detail/CVE-2022-41915

The Vert.x and vertx-lib upgrades indirectly upgrade
netty-handler from 4.1.85.Final to Netty 4.1.100.Final fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2023-34462

The Vert.x and vertx-lib upgrades indirectly upgrade
vertx-web from 4.1.85.Final to Netty 4.1.100.Final fixing Directory Traversal:
https://nvd.nist.gov/vuln/detail/CVE-2023-24815

The Vert.x and vertx-lib upgrades indirectly upgrade
snakeyaml from 1.32 to 2.0 fixing Arbitrary Code Execution:
https://nvd.nist.gov/vuln/detail/CVE-2022-1471
https://wiki.folio.org/display/SEC/SnakeYaml+SafeConstructor