### PR TITLE
MODSET-21: Release mod-settings. Fix version: 1.1.0 (Ramsons)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
-## 1.0.3 IN PROGRESS
-* Update vertx dependencies to 4.5.3
-* Add new document [How to add new settings to the mod-settings module](doc/HOWTO.md). Fixes MODSET-18.
+## 1.1.0
 * Upgrade dependencies (folio-vertx-lib, ...) for Ramsons. [MODSET-22](https://folio-org.atlassian.net/browse/MODSET-22)
+* Add descriptor validator plugin. Change permission name to mod-settings.entries.put
+* [MODSET-17: Use .withTransaction, Promise and better logging](https://folio-org.atlassian.net/browse/MODSET-17)
+* Add new document [How to add new settings to the mod-settings module](doc/HOWTO.md). Fixes MODSET-18.
+
+## 1.0.3
+* [FOLIO-3944 Upgrade Actions for API-related Workflows](https://folio-org.atlassian.net/browse/FOLIO3-944)
 
 ## 1.0.2 2024-12-06
 * Update library dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-settings</artifactId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <name>mod-settings</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/mod-settings</url>
     <connection>scm:git:git://github.com/folio-org/mod-settings.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-settings.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.1.0</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-settings</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>mod-settings</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/mod-settings</url>
     <connection>scm:git:git://github.com/folio-org/mod-settings.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-settings.git</developerConnection>
-    <tag>v1.1.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODSET-21

Needed to clean up news a bit. Bumped from 1.0.3 to 1.1.0 because of the interface change due to the perm renaming.