### PR TITLE
MODSET-27 use correct permission-names in doc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Add descriptor validator plugin. Change permission name to mod-settings.entries.put
 * [MODSET-17: Use .withTransaction, Promise and better logging](https://folio-org.atlassian.net/browse/MODSET-17)
 * Add new document [How to add new settings to the mod-settings module](doc/HOWTO.md). Fixes MODSET-18.
+* Correctly document permission names. Fixes MODSET-27.
 
 ## 1.0.3
 * [FOLIO-3944 Upgrade Actions for API-related Workflows](https://folio-org.atlassian.net/browse/FOLIO3-944)

--- a/doc/HOWTO.md
+++ b/doc/HOWTO.md
@@ -47,7 +47,7 @@ A scope's only manifestation in a module descriptor is in the permissions that a
 
 Note that, although these permissions are in the `mod-settings` namespace, they are defined by the client module (e.g. in the present example `mod-inventory`). This is a unique situation in FOLIO, required by the need for `mod-settings` to determine the name of the permission to check when all it knows is the scope and the operation (read or write).
 
-(There are two more pairs of permissions that can be defined for a scope: read and write for "user", meaning a user-specific value of a setting for _any_ user; and for "owner", meaning the _current_ user's own user-specific value. These permissions are named `mod-settings.user.read.SCOPE`/`mod-settings.user.write.SCOPE` and `mod-settings.owner.read.SCOPE`/`mod-settings.owner.write.SCOPE`. These have not yet been used in real code, but are available when needed.)
+(There are two more pairs of permissions that can be defined for a scope: read and write for "users", meaning a user-specific value of a setting for _any_ user; and for "owner", meaning the _current_ user's own user-specific value. These permissions are named `mod-settings.users.read.SCOPE`/`mod-settings.users.write.SCOPE` and `mod-settings.owner.read.SCOPE`/`mod-settings.owner.write.SCOPE`. These have not yet been used in real code, but are available when needed.)
 
 
 ### 3. Assign necessary permissions to users

--- a/doc/HOWTO.md
+++ b/doc/HOWTO.md
@@ -41,13 +41,13 @@ One a scope has been defined, it is laborious and error-prone to change its name
 
 ### 2. Define relevant permissions for the scopes
 
-A scope's only manifestation in a module descriptor is in the permissions that allow user to access keys in that scope. Typically two permissions are defined: 
+A scope's only manifestation in a module descriptor is in the permissions that allow user to access keys in that scope. Typically two permissions are defined:
 
 `mod-settings.global.read.SCOPE` allows a user to read settings in the named scope, and `mod-settings.global.write.SCOPE` allows a user to write settings in the named scope. For example, `mod-settings.global.read.mod-inventory.prefs` allows a user to read settings from the scope `mod-inventory.prefs`. The settings module itself enforces this requirement.
 
 Note that, although these permissions are in the `mod-settings` namespace, they are defined by the client module (e.g. in the present example `mod-inventory`). This is a unique situation in FOLIO, required by the need for `mod-settings` to determine the name of the permission to check when all it knows is the scope and the operation (read or write).
 
-(There are two more pairs of permissions that can be defined for a scope: read and write for "user", meaning a user-specific value of a setting; and for "self", meaning the current user's own user-specific value. These permissions are named `mod-settings.user.read.SCOPE`/`mod-settings.user.write.SCOPE` and `mod-settings.self.read.SCOPE`/`mod-settings.self.write.SCOPE`. These have not yet been used in real code, but are available when needed.)
+(There are two more pairs of permissions that can be defined for a scope: read and write for "user", meaning a user-specific value of a setting for _any_ user; and for "owner", meaning the _current_ user's own user-specific value. These permissions are named `mod-settings.user.read.SCOPE`/`mod-settings.user.write.SCOPE` and `mod-settings.owner.read.SCOPE`/`mod-settings.owner.write.SCOPE`. These have not yet been used in real code, but are available when needed.)
 
 
 ### 3. Assign necessary permissions to users

--- a/src/main/resources/openapi/settings.yaml
+++ b/src/main/resources/openapi/settings.yaml
@@ -16,11 +16,11 @@ paths:
     get:
       description: >
         Get settings with optional CQL query.
-        If X-Okapi-Permissions includes settings.global.read then settings
+        If X-Okapi-Permissions includes mod-settings.global.read.SCOPE then settings
         without a userId are returned.
-        If X-Okapi-Permissions includes settings.users.read then settings
+        If X-Okapi-Permissions includes mod-settings.users.read.SCOPE then settings
         with a userId are returned.
-        If X-Okapi-Permissions includes settings.owner.read then settings
+        If X-Okapi-Permissions includes mod-settings.owner.read.SCOPE then settings
         with userId = current-user are returned.
       operationId: getSettings
       responses:
@@ -39,11 +39,11 @@ paths:
     post:
       description: >
         Create setting entry.
-        If X-Okapi-Permissions includes settings.global.write, then a setting without
+        If X-Okapi-Permissions includes mod-settings.global.write.SCOPE, then a setting without
         a userId may be created.
-        If X-Okapi-Permissions includes settings.users.write, then a setting with a
+        If X-Okapi-Permissions includes mod-settings.users.write.SCOPE, then a setting with a
         userId may be created.
-        If X-Okapi-Permissions includes settings.owner.write, then a setting with
+        If X-Okapi-Permissions includes mod-settings.owner.write.SCOPE, then a setting with
         userId = current-user may be created.
       operationId: postSetting
       requestBody:
@@ -79,11 +79,11 @@ paths:
     get:
       description: >
         Get setting.
-        If X-Okapi-Permissions includes settings.global.read, then a setting without
+        If X-Okapi-Permissions includes mod-settings.global.read.SCOPE, then a setting without
         a userId may be retrieved.
-        If X-Okapi-Permissions includes settings.users.read, then a setting with a
+        If X-Okapi-Permissions includes mod-settings.users.read.SCOPE, then a setting with a
         userId may be retrieved.
-        If X-Okapi-Permissions includes settings.owner.read, then a setting with
+        If X-Okapi-Permissions includes mod-settings.owner.read.SCOPE, then a setting with
         userId = current-user may be retrieved.
       operationId: getSetting
       responses:
@@ -104,11 +104,11 @@ paths:
     put:
       description: >
         Update setting.
-        If X-Okapi-Permissions includes settings.global.write, then a setting without
+        If X-Okapi-Permissions includes mod-settings.global.write.SCOPE, then a setting without
         a userId may be updated.
-        If X-Okapi-Permissions includes settings.users.write, then a setting with a
+        If X-Okapi-Permissions includes mod-settings.users.write.SCOPE, then a setting with a
         userId may be updated.
-        If X-Okapi-Permissions includes settings.owner.write, then a setting with
+        If X-Okapi-Permissions includes mod-settings.owner.write.SCOPE, then a setting with
         userId = current-user may be updated.
       operationId: putSetting
       requestBody:
@@ -132,11 +132,11 @@ paths:
     delete:
       description: >
         Delete setting.
-        If X-Okapi-Permissions includes settings.global.write, then a setting without
+        If X-Okapi-Permissions includes mod-settings.global.write.SCOPE, then a setting without
         a userId may be deleted.
-        If X-Okapi-Permissions includes settings.users.write, then a setting with a
+        If X-Okapi-Permissions includes mod-settings.users.write.SCOPE, then a setting with a
         userId may be deleted.
-        If X-Okapi-Permissions includes settings.owner.write, then a setting with
+        If X-Okapi-Permissions includes mod-settings.owner.write.SCOPE, then a setting with
         userId = current-user may be deleted.
       operationId: deleteSetting
       responses:
@@ -160,11 +160,11 @@ paths:
         Upload settings. The entries are inserted or updated depending on whether
         key, scope, userId already. Each entry gets a unique identifier assigned
         if it's a new setting. The id must not be supplied.
-        If X-Okapi-Permissions includes settings.global.write, then a setting without
+        If X-Okapi-Permissions includes mod-settings.global.write.SCOPE, then a setting without
         a userId may be created/updated.
-        If X-Okapi-Permissions includes settings.users.write, then a setting with a
+        If X-Okapi-Permissions includes mod-settings.users.write.SCOPE, then a setting with a
         userId may be created/updated.
-        If X-Okapi-Permissions includes settings.owner.write, then a setting with
+        If X-Okapi-Permissions includes mod-settings.owner.write.SCOPE, then a setting with
         userId = current-user may be created/updated.
       operationId: uploadSettings
       requestBody:


### PR DESCRIPTION
Use correct permission names in documentation.

Refs [MODSET-27](https://folio-org.atlassian.net/browse/MODSET-27)

Attn: @kurtnordstrom