### PR TITLE
MODSET-46: Bump dependencies for Trillium (Vertx 5.0.10, …)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>5.0.4</vertx.version>
-    <okapi.version>7.0.0</okapi.version>
-    <vertxlib.version>4.1.1</vertxlib.version>
+    <vertx.version>5.0.10</vertx.version>
+    <okapi.version>7.0.3</okapi.version>
+    <vertxlib.version>4.1.2</vertxlib.version>
     <vertx.launcher>io.vertx.launcher.application.VertxApplication</vertx.launcher>
     <vertx.verticle>org.folio.settings.server.main.MainVerticle</vertx.verticle>
     <java.version>21</java.version>
@@ -172,12 +172,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -192,7 +192,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.24.3</version>
+        <version>2.25.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -206,7 +206,7 @@
       <dependency>
         <groupId>org.folio</groupId>
         <artifactId>util</artifactId>
-        <version>35.4.0</version>
+        <version>36.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.folio</groupId>
@@ -236,12 +236,12 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>5.5.6</version>
+        <version>5.5.7</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.21.4</version>
+        <version>2.0.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -253,7 +253,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -267,11 +267,19 @@
   </dependencyManagement>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>openapi/</exclude>
+        </excludes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -297,7 +305,7 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>filter-descriptor-inputs</id>
@@ -348,7 +356,7 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.1</version>
+        <version>3.15.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
             <compilerArgs>
@@ -360,13 +368,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>3.5.5</version>
         <executions>
           <execution>
             <goals>
@@ -380,7 +388,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.1.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -397,7 +404,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>12.2.0</version>
+            <version>13.4.0</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -441,7 +448,7 @@
       <plugin>
         <groupId>org.folio</groupId>
         <artifactId>openapi-deref-plugin</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.1</version>
         <executions>
           <execution>
             <id>dereference-books</id>

--- a/src/test/java/org/folio/settings/server/TestBase.java
+++ b/src/test/java/org/folio/settings/server/TestBase.java
@@ -18,7 +18,7 @@ import org.folio.settings.server.main.MainVerticle;
 import org.folio.tlib.postgres.testing.TenantPgPoolContainer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -38,7 +38,7 @@ public class TestBase {
   protected static final String MODULE_VERSION = "1.0.0";
   protected static final String MODULE_ID = MODULE_PREFIX + "-" + MODULE_VERSION;
 
-  public static PostgreSQLContainer<?> postgresSQLContainer;
+  public static PostgreSQLContainer postgresSQLContainer;
 
   @AfterClass
   public static void afterClass(TestContext context) {

--- a/src/test/java/org/folio/settings/server/TestContainersSupport.java
+++ b/src/test/java/org/folio/settings/server/TestContainersSupport.java
@@ -4,7 +4,7 @@ import org.folio.tlib.postgres.TenantPgPool;
 import org.folio.tlib.postgres.testing.TenantPgPoolContainer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -15,7 +15,7 @@ import io.vertx.junit5.VertxExtension;
 public interface TestContainersSupport {
 
   @Container
-  PostgreSQLContainer<?> postgresContainer = TenantPgPoolContainer.create();
+  PostgreSQLContainer postgresContainer = TenantPgPoolContainer.create();
 
   @BeforeAll
   static void setupContainers() {


### PR DESCRIPTION
Bump dependencies for Trillium:

* bump Vert.x from 5.0.4 to 5.0.10
* bump okapi-common from 7.0.0 to 7.0.3
* bump folio-vertx-lib from 4.1.1 to 4.1.2
* bump log4j from 2.24.3 to 2.25.4
* bump org.folio:util from 35.4.0 to 36.0.0

Also bump build and test dependencies.