### PR TITLE
MODSET-44: Make numberingSystem optional in /locale

### DIFF
--- a/src/main/java/org/folio/settings/server/service/LocaleService.java
+++ b/src/main/java/org/folio/settings/server/service/LocaleService.java
@@ -63,7 +63,7 @@ public final class LocaleService {
   }
 
   private static Future<Void> response500(RoutingContext ctx, Throwable t) {
-    log.error("500 internal server error", t.getMessage(), t);
+    log.error("500 internal server error", t);
     return HttpResponse.responseText(ctx, HTTP_INTERNAL_ERROR).end();
   }
 }

--- a/src/main/java/org/folio/settings/server/service/LocaleService.java
+++ b/src/main/java/org/folio/settings/server/service/LocaleService.java
@@ -9,12 +9,17 @@ import static org.folio.settings.server.util.StringUtil.isBlank;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.HttpResponse;
 import org.folio.settings.server.data.LocaleSettings;
 import org.folio.settings.server.storage.LocaleStorage;
+import org.folio.settings.server.util.LocaleUtil;
 import org.folio.tlib.util.TenantUtil;
 
 public final class LocaleService {
+  private static final Logger log = LogManager.getLogger(LocaleService.class);
+
   private LocaleService() {
   }
 
@@ -42,19 +47,23 @@ public final class LocaleService {
       response400(ctx, "timezone missing");
     } else if (isBlank(localeSettings.getCurrency())) {
       response400(ctx, "currency missing");
-    } else if (!"latn".equals(localeSettings.getNumberingSystem())
-        && !"arab".equals(localeSettings.getNumberingSystem())) {
-      response400(ctx, "numberingSystem must be latn or arab");
+    } else if (!LocaleUtil.isValidNumberingSystem(localeSettings.getNumberingSystem())) {
+      response400(ctx, "numberingSystem must be latn or arab, or not defined");
     } else {
       return new LocaleStorage(ctx.vertx(), TenantUtil.tenant(ctx))
           .updateLocale(localeSettings)
           .compose(x -> HttpResponse.responseText(ctx, HTTP_CREATED).end(),
-              e -> HttpResponse.responseText(ctx, HTTP_INTERNAL_ERROR).end());
+              e -> response500(ctx, e));
     }
     return Future.succeededFuture();
   }
 
   private static void response400(RoutingContext ctx, String msg) {
     HttpResponse.responseText(ctx, HTTP_BAD_REQUEST).end(msg);
+  }
+
+  private static Future<Void> response500(RoutingContext ctx, Throwable t) {
+    log.error("500 internal server error", t.getMessage(), t);
+    return HttpResponse.responseText(ctx, HTTP_INTERNAL_ERROR).end();
   }
 }

--- a/src/main/java/org/folio/settings/server/storage/LocaleStorage.java
+++ b/src/main/java/org/folio/settings/server/storage/LocaleStorage.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.folio.okapi.common.SemVer;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.settings.server.data.LocaleSettings;
+import org.folio.settings.server.util.LocaleUtil;
 import org.folio.tlib.TenantInitConf;
 import org.folio.tlib.postgres.TenantPgPool;
 import org.folio.util.PercentCodec;
@@ -19,6 +20,7 @@ import org.folio.util.PercentCodec;
 public class LocaleStorage {
 
   private static final SemVer SEM_VER_1_3_0 = new SemVer("1.3.0");
+  private static final SemVer SEM_VER_1_3_1 = new SemVer("1.3.1");
 
   private final TenantPgPool pool;
 
@@ -48,7 +50,7 @@ public class LocaleStorage {
            locale text NOT NULL,
            currency text NOT NULL,
            timezone text NOT NULL,
-           numberingsystem text NOT NULL)
+           numberingsystem text);
         """.formatted(localeTable),
 
         """
@@ -59,7 +61,7 @@ public class LocaleStorage {
                     'en-US',
                     'USD',
                     'UTC',
-                    'latn')
+                    null)
             ON CONFLICT DO NOTHING;
           EXCEPTION WHEN SQLSTATE 'P0001' THEN NULL;
           END
@@ -87,17 +89,29 @@ public class LocaleStorage {
         ));
   }
 
+  private Future<Void> allowNullInNumberingSystem() {
+    return pool.execute(List.of(
+        """
+        ALTER TABLE %s ALTER COLUMN numberingsystem DROP NOT NULL;
+        """.formatted(localeTable)));
+  }
+
   private Future<Void> migrateData(TenantInitConf tenantInitConf, String oldVersion) {
     var oldSemVersion = new SemVer(oldVersion);
-    if (SEM_VER_1_3_0.compareTo(oldSemVersion) <= 0) {
-      return Future.succeededFuture();
+    var future = Future.<Void>succeededFuture();
+
+    if (oldSemVersion.compareTo(SEM_VER_1_3_0) < 0) {
+      var webClient = WebClient.create(tenantInitConf.vertx());
+      future = future.compose(x -> getAndDeleteFromModConfiguration(tenantInitConf, webClient))
+          .compose(this::updateLocaleSanitized)
+          .onComplete(x -> webClient.close());
     }
 
-    var webClient = WebClient.create(tenantInitConf.vertx());
-    return getAndDeleteFromModConfiguration(tenantInitConf, webClient)
-        .compose(this::updateLocaleSanitized)
-        .onComplete(x -> webClient.close())
-        .mapEmpty();
+    if (oldSemVersion.compareTo(SEM_VER_1_3_1) < 0) {
+      future = future.compose(x -> allowNullInNumberingSystem());
+    }
+
+    return future;
   }
 
   private static Future<LocaleSettings> getAndDeleteFromModConfiguration(
@@ -173,9 +187,8 @@ public class LocaleStorage {
     if (isBlank(localeSettings.getCurrency())) {
       localeSettings.setCurrency("USD");
     }
-    if (!"latn".equals(localeSettings.getNumberingSystem())
-        && !"arab".equals(localeSettings.getNumberingSystem())) {
-      localeSettings.setNumberingSystem("latn");
+    if (!LocaleUtil.isValidNumberingSystem(localeSettings.getNumberingSystem())) {
+      localeSettings.setNumberingSystem(null);
     }
     return updateLocale(localeSettings);
   }

--- a/src/main/java/org/folio/settings/server/util/LocaleUtil.java
+++ b/src/main/java/org/folio/settings/server/util/LocaleUtil.java
@@ -1,6 +1,9 @@
 package org.folio.settings.server.util;
 
 public final class LocaleUtil {
+  private LocaleUtil() {
+  }
+
   /**
    * Is "latn", "arab", or null.
    */

--- a/src/main/java/org/folio/settings/server/util/LocaleUtil.java
+++ b/src/main/java/org/folio/settings/server/util/LocaleUtil.java
@@ -1,0 +1,14 @@
+package org.folio.settings.server.util;
+
+public final class LocaleUtil {
+  /**
+   * Is "latn", "arab", or null.
+   */
+  public static boolean isValidNumberingSystem(String s) {
+    return switch (s) {
+      case null -> true;
+      case "latn", "arab" -> true;
+      default -> false;
+    };
+  }
+}

--- a/src/main/resources/openapi/schemas/locale.json
+++ b/src/main/resources/openapi/schemas/locale.json
@@ -23,7 +23,6 @@
   "required": [
     "locale",
     "currency",
-    "timezone",
-    "numberingSystem"
+    "timezone"
   ]
 }

--- a/src/test/java/org/folio/settings/server/service/LocaleServiceTest.java
+++ b/src/test/java/org/folio/settings/server/service/LocaleServiceTest.java
@@ -12,7 +12,6 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.sqlclient.Tuple;
-
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.settings.server.TestContainersSupport;
 import org.folio.settings.server.main.MainVerticle;
@@ -22,6 +21,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class LocaleServiceTest implements TestContainersSupport {
@@ -43,6 +43,7 @@ class LocaleServiceTest implements TestContainersSupport {
   @BeforeAll
   static void beforeAll(Vertx vertx, VertxTestContext vtc) {
     RestAssured.baseURI = "http://localhost:8081";
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     vertx.deployVerticle(new MainVerticle())
     .compose(x -> deployModConfigurationMock(vertx))
     .compose(x -> postTenant(vertx, "http://localhost:8081", "diku", "1.3.0"))
@@ -87,8 +88,8 @@ class LocaleServiceTest implements TestContainersSupport {
   @CsvSource({
     "locale, ''",
     "currency, ' '",
-    "timezone, '  '",
-    "numberingSystem,",
+    "timezone,",
+    "numberingSystem, ' '",
   })
   void blank(String key, String value) {
     RestAssured.given()
@@ -102,12 +103,18 @@ class LocaleServiceTest implements TestContainersSupport {
   }
 
   @ParameterizedTest
-  @ValueSource(strings={"latn", "arab"})
+  @NullSource
+  @ValueSource(strings={"latn", "arab", ""})
   void numberingSystem(String value) {
+    var json = getDe().put("numberingSystem", value);
+    if ("".equals(value)) {
+      assertThat(json.remove("numberingSystem"), is(""));
+      value = null;
+    }
     RestAssured.given()
     .header(XOkapiHeaders.TENANT, "diku")
     .header("Content-Type", "application/json")
-    .body(getDe().put("numberingSystem", value).encode())
+    .body(json.encode())
     .put("/locale")
     .then()
     .statusCode(201);
@@ -121,7 +128,7 @@ class LocaleServiceTest implements TestContainersSupport {
   }
 
   @ParameterizedTest
-  @ValueSource(strings={"LATN", "latin", " latn"})
+  @ValueSource(strings={"LATN", "latin", " latn", ""})
   void illegalNumberingSystem(String value) {
     RestAssured.given()
     .header(XOkapiHeaders.TENANT, "diku")


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODSET-44

Each languageRegion has a default numberingSystem.

Therefore we cannot assume latn as the numberingSystem if no numberingSystem is provided.

Fix: Make numberingSystem optional. On migration keep it unset in mod-settings if it is unset in mod-configuration.

Add migration from buggy release 1.3.0.