### PR TITLE
Fix datetime pattern in TenantAddressesServiceTest

### DIFF
--- a/src/test/java/org/folio/settings/server/service/TenantAddressesServiceTest.java
+++ b/src/test/java/org/folio/settings/server/service/TenantAddressesServiceTest.java
@@ -34,7 +34,7 @@ class TenantAddressesServiceTest implements TestContainersSupport {
 
   private static final String TEST_USER_ID = "11111111-1111-1111-1111-111111111111";
   private static final String ISO_DATETIME_PATTERN =
-      "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{2,6})?\\+00:00";
+      "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?\\+00:00";
   private static final String TENANT = "diku";
 
   public static final String ADDRESS_CONFIGS = """


### PR DESCRIPTION
This build
https://github.com/folio-org/mod-settings/actions/runs/24511192816/job/71642547322
failed because the second fraction had only 1 digit:

```
Error:    TenantAddressesServiceTest.createTenantAddress:129 1 expectation failed.
JSON path metadata.createdDate doesn't match.
Expected: a string matching the pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{2,6})?\+00:00'
  Actual: 2026-04-16T12:52:17.6+00:00
```

Fix: Allow single digit second fraction.